### PR TITLE
Add quotes for inputs and output paths as they can contain spaces

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: az bicep build --file ${{ inputs.bicepFilePath }} --outfile ${{ inputs.outputFilePath }}
+    - run: az bicep build --file "${{ inputs.bicepFilePath }}" --outfile "${{ inputs.outputFilePath }}"
       shell: bash


### PR DESCRIPTION
This PR aims to ensure spaces in input or output paths work.
Otherwise an error occurs as you can see in this [build result:](https://github.com/jbpaux/azure-orphan-resources/runs/6915884797?check_suite_focus=true) 